### PR TITLE
Adds a new field to exclude adaptive preset from auto switch

### DIFF
--- a/Universal x86 Tuning Utility/Services/AdaptivePresetManager.cs
+++ b/Universal x86 Tuning Utility/Services/AdaptivePresetManager.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -42,6 +43,10 @@ namespace Universal_x86_Tuning_Utility.Services
         public bool isRecap { get; set; }
         public int Sharpness { get; set; }
         public int ResScaleIndex { get; set; }
+
+        [DefaultValue(true)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public bool isAutoSwitch { get; set; }
     }
 
     public class AdaptivePresetManager

--- a/Universal x86 Tuning Utility/Views/Pages/Adaptive.xaml
+++ b/Universal x86 Tuning Utility/Views/Pages/Adaptive.xaml
@@ -49,10 +49,38 @@
 
             <ScrollViewer Name="mainScroll" Margin="0,9,0,0" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" CanContentScroll="False" PanningMode="VerticalFirst" Stylus.IsFlicksEnabled="False" Stylus.IsTouchFeedbackEnabled="True" IsDeferredScrollingEnabled="False" DockPanel.Dock="Top" ScrollChanged="mainScroll_ScrollChanged">
                 <StackPanel Name="mainCon">
+                    <ui:CardControl Name="sdEnabled"
+                             IsEnabled="True"
+                             Icon="PresenceAvailable10"
+                             VerticalAlignment="Top"
+                             Margin="0,0,15,0">
+                        
+                        <ui:CardControl.Header>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                    <TextBlock
+                                        FontSize="14"
+                                        FontWeight="Medium"
+                                        Text="Auto Switch" />
+                                    <TextBlock
+                                        FontSize="12"
+                                        Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                        Text="Enable this preset for automatic switching. Can be used to exclude games/apps from auto switch."/>
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal" Grid.Column="1">
+                                    <ui:ToggleSwitch Name="tsAutoSwitch" Margin="0,0,9,0"/>
+                                </StackPanel>
+                            </Grid>
+                        </ui:CardControl.Header>
+                    </ui:CardControl>
                 <ui:CardExpander Name="sdBasic"
             IsEnabled="True"
             IsExpanded="False"
-            Icon="Book20" VerticalAlignment="Top" Margin="0,0,15,0">
+            Icon="Book20" VerticalAlignment="Top" Margin="0,8,15,0">
                     <ui:CardExpander.Header>
                         <Grid>
                             <Grid.ColumnDefinitions>

--- a/Universal x86 Tuning Utility/Views/Pages/Adaptive.xaml.cs
+++ b/Universal x86 Tuning Utility/Views/Pages/Adaptive.xaml.cs
@@ -89,6 +89,7 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                 nudMinGfxClk.Value = 400;
                 nudTemp.Value = 95;
                 nudMinCpuClk.Value = 1500;
+                tsAutoSwitch.IsChecked = true;
 
                 await Task.Run(() => Game_Manager.installedGames = Game_Manager.syncGame_Library());
 
@@ -129,6 +130,7 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                             isAntiLag = (bool)cbAntiLag.IsChecked,
                             isImageSharp = (bool)cbImageSharp.IsChecked,
                             isSync = (bool)cbSync.IsChecked,
+                            isAutoSwitch = (bool)tsAutoSwitch.IsChecked
                         };
                         adaptivePresetManager.SavePreset(item.gameName, preset);
                     }
@@ -249,6 +251,8 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
 
                 if (myPreset != null)
                 {
+                    tsAutoSwitch.IsChecked = myPreset.isAutoSwitch;
+
                     nudTemp.Value = myPreset.Temp;
                     nudPowerLimit.Value = myPreset.Power;
                     nudCurve.Value = myPreset.CO;
@@ -317,6 +321,7 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                     isRecap = (bool)cbAutoCap.IsChecked,
                     Sharpness = (int)nudSharp.Value,
                     ResScaleIndex = (int)cbxResScale.SelectedIndex,
+                    isAutoSwitch = (bool)tsAutoSwitch.IsChecked
                 };
                 adaptivePresetManager.SavePreset(presetName, preset);
             }
@@ -591,6 +596,17 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
 
                             if (executablePath.Contains(item.path))
                             {
+                                bool autoSwitch = true;
+                                AdaptivePreset preset = adaptivePresetManager.GetPreset(item.gameName);
+                                if (preset != null)
+                                {
+                                    autoSwitch = preset.isAutoSwitch;
+                                }
+                                if (!autoSwitch)
+                                {
+                                    continue;
+                                }
+
                                 runningGameName = item.gameName;
                                 return;
                             }


### PR DESCRIPTION
Could be useful for avoiding having to [hardcode specific game names to exclude](https://github.com/JamesCJ60/Universal-x86-Tuning-Utility/blob/b4f6abe9ba10f90bba1781b05be312c452339d21/Universal%20x86%20Tuning%20Utility/Scripts/Game_Manager.cs#L68) .

For the immediate (my personal) use case of excluding "Lossless Scaling" from being selected over apps with game names that come after it (because of early return [here](https://github.com/JamesCJ60/Universal-x86-Tuning-Utility/blob/b4f6abe9ba10f90bba1781b05be312c452339d21/Universal%20x86%20Tuning%20Utility/Views/Pages/Adaptive.xaml.cs#L595))