### PR TITLE
Require adminstrator in app.manifest

### DIFF
--- a/Universal x86 Tuning Utility/App.xaml.cs
+++ b/Universal x86 Tuning Utility/App.xaml.cs
@@ -55,13 +55,6 @@ namespace Universal_x86_Tuning_Utility
             return _host.Services.GetService(typeof(T)) as T;
         }
 
-        public static bool IsAdministrator()
-        {
-            WindowsIdentity identity = WindowsIdentity.GetCurrent();
-            WindowsPrincipal principal = new WindowsPrincipal(identity);
-            return principal.IsInRole(WindowsBuiltInRole.Administrator);
-        }
-
         public static string version = "2.2.10";
         private Mutex mutex;
         private const string MutexName = "UniversalX86TuningUtility";
@@ -86,28 +79,15 @@ namespace Universal_x86_Tuning_Utility
             
             try
             {
-                if (!App.IsAdministrator())
+                try
                 {
-                    // Restart and run as admin
-                    var exeName = Process.GetCurrentProcess().MainModule.FileName;
-                    ProcessStartInfo startInfo = new ProcessStartInfo(exeName);
-                    startInfo.Verb = "runas";
-                    startInfo.UseShellExecute = true;
-                    startInfo.Arguments = "restart";
-                    Process.Start(startInfo);
-                    Environment.Exit(0);
+                    await Task.Run(() => product = GetSystemInfo.Product);
+                    Display.setUpLists();
                 }
-                else
+                catch (Exception ex)
                 {
-                    try
-                    {
-                        await Task.Run(() => product = GetSystemInfo.Product);
-                        Display.setUpLists();
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Logger.Error(ex, "Failed to setup product and display refresh rates");
-                    }
+                    Log.Logger.Error(ex, "Failed to setup product and display refresh rates");
+                }
 
                     _host = Host
                 .CreateDefaultBuilder()
@@ -256,8 +236,7 @@ namespace Universal_x86_Tuning_Utility
 
                     await _host.StartAsync();
 
-                    await Task.Run(() => Game_Manager.installedGames = Game_Manager.syncGame_Library());
-                }
+                await Task.Run(() => Game_Manager.installedGames = Game_Manager.syncGame_Library());
             } 
             catch (Exception ex) 
             { 

--- a/Universal x86 Tuning Utility/App.xaml.cs
+++ b/Universal x86 Tuning Utility/App.xaml.cs
@@ -89,152 +89,152 @@ namespace Universal_x86_Tuning_Utility
                     Log.Logger.Error(ex, "Failed to setup product and display refresh rates");
                 }
 
-                    _host = Host
-                .CreateDefaultBuilder()
-                .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)); })
-                .ConfigureLogging(logging =>
-                {
-                    logging.ClearProviders();
-                    logging.AddSerilog();
-                })
-                .ConfigureServices((context, services) =>
-                {
-                    // App Host
-                    services.AddHostedService<ApplicationHostService>();
-
-                    // Page resolver service
-                    services.AddSingleton<IPageService, PageService>();
-
-                    try
+                _host = Host
+                    .CreateDefaultBuilder()
+                    .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)); })
+                    .ConfigureLogging(logging =>
                     {
-                        Settings.Default.isASUS = false;
-                        Settings.Default.Save();
-
-                        if (product.Contains("ROG") || product.Contains("TUF") || product.Contains("Ally") || product.Contains("Flow") || product.ToLower().Contains("vivobook") || product.ToLower().Contains("zenbook"))
-                        {
-                            wmi = new ASUSWmi();
-                            
-                            services.AddSingleton(wmi);
-                            services.AddSingleton<XgMobileConnectionService>();
-
-                            Settings.Default.isASUS = true;
-                            Settings.Default.Save();
-                        }
-                    }
-                    catch (Exception ex)
+                        logging.ClearProviders();
+                        logging.AddSerilog();
+                    })
+                    .ConfigureServices((context, services) =>
                     {
-                        Log.Logger.Error(ex, "Failed to setup ASUS WMI services");
-                    }
+                        // App Host
+                        services.AddHostedService<ApplicationHostService>();
 
-                    // Theme manipulation
-                    services.AddSingleton<IThemeService, ThemeService>();
-
-                    // TaskBar manipulation
-                    services.AddSingleton<ITaskBarService, TaskBarService>();
-
-                    // Service containing navigation, same as INavigationWindow... but without window
-                    services.AddSingleton<INavigationService, NavigationService>();
-
-                    // Main window with navigation
-                    services.AddScoped<INavigationWindow, Views.Windows.MainWindow>();
-                    services.AddScoped<ViewModels.MainWindowViewModel>();
-
-                    // Views and ViewModels
-                    services.AddScoped<Views.Pages.DashboardPage>();
-                    services.AddScoped<ViewModels.DashboardViewModel>();
-                    services.AddScoped<Views.Pages.CustomPresets>();
-                    services.AddScoped<Views.Pages.Premade>();
-                    services.AddScoped<Views.Pages.Adaptive>();
-                    services.AddScoped<Views.Pages.Automations>();
-                    services.AddScoped<Views.Pages.FanControl>();
-                    services.AddScoped<Views.Pages.SystemInfo>();
-                    services.AddScoped<ViewModels.GamesViewModel>();
-                    services.AddScoped<Views.Pages.Games>();
-                    services.AddScoped<ViewModels.CustomPresetsViewModel>();
-                    services.AddScoped<Views.Pages.DataPage>();
-                    services.AddScoped<ViewModels.DataViewModel>();
-                    services.AddScoped<Views.Pages.SettingsPage>();
-                    services.AddScoped<ViewModels.SettingsViewModel>();
-
-                    // Configuration
-                    services.Configure<AppConfig>(context.Configuration.GetSection(nameof(AppConfig)));
-                }).Build();
-
-                    _logger = _host.Services.GetRequiredService<ILogger<App>>();
-
-                    _ = Tablet.TabletDevices;
-                    bool firstBoot = false;
-                    try
-                    {
-                        if (Settings.Default.SettingsUpgradeRequired)
-                        {
-                            try
-                            {
-                                Settings.Default.Upgrade();
-                                Settings.Default.SettingsUpgradeRequired = false;
-                                Settings.Default.Save();
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogError(ex, "Failed to update settings on startup");
-                            }
-                        }
-
-                        firstBoot = Settings.Default.FirstBoot;
-                    }
-                    catch (ConfigurationErrorsException ex)
-                    {
-                        string filename = ((ConfigurationErrorsException)ex.InnerException).Filename;
-                        File.Delete(filename);
-                        Settings.Default.Reload();
-                    }
-
-                    bool createdNew;
-                    mutex = new Mutex(true, MutexName, out createdNew);
-
-                    if (!createdNew)
-                    {
-                        _logger.LogWarning("Failed to start app, as there is already running uxtu instance. Shutting down");
-                        MessageBox.Show("An instance of Universal x86 Tuning Utility is already open!", "Error starting Universal x86 Tuning Utility");
-                        // Close the new instance
-                        Shutdown();
-                        return;
-                    }
-
-                    if (File.Exists("C:\\Universal.x86.Tuning.Utility.V2.msi")) File.Delete("C:\\Universal.x86.Tuning.Utility.V2.msi");
-
-                    Family.setCpuFamily();
-                    Family.setCpuFamily();
-                    string path = System.Reflection.Assembly.GetEntryAssembly().Location;
-                    path = path.Replace("Universal x86 Tuning Utility.dll", null);
-
-                    if (firstBoot || Settings.Default.Path != path)
-                    {
-                        Settings.Default.Path = path;
-                        Settings.Default.FirstBoot = false;
-                        if (Family.FAM > Family.RyzenFamily.Rembrandt || Family.FAM == Family.RyzenFamily.Mendocino) Settings.Default.polling = 3;
-                        Settings.Default.Save();
-
-                        //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFAUTONOMOUS", 1, true);
-                        //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFAUTONOMOUS", 1, false);
-                        //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFEPP", 50, true);
-                        //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFEPP", 50, false);
-                        //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFEPP1", 50, true);
-                        //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFEPP1", 50, false);
+                        // Page resolver service
+                        services.AddSingleton<IPageService, PageService>();
 
                         try
                         {
-                            await Task.Run(() => UnblockFilesInDirectory(path));
+                            Settings.Default.isASUS = false;
+                            Settings.Default.Save();
+
+                            if (product.Contains("ROG") || product.Contains("TUF") || product.Contains("Ally") || product.Contains("Flow") || product.ToLower().Contains("vivobook") || product.ToLower().Contains("zenbook"))
+                            {
+                                wmi = new ASUSWmi();
+                            
+                                services.AddSingleton(wmi);
+                                services.AddSingleton<XgMobileConnectionService>();
+
+                                Settings.Default.isASUS = true;
+                                Settings.Default.Save();
+                            }
                         }
                         catch (Exception ex)
                         {
-                            _logger.LogError(ex, "Failed to unblock files in {dir} directory", path);
+                            Log.Logger.Error(ex, "Failed to setup ASUS WMI services");
+                        }
+
+                        // Theme manipulation
+                        services.AddSingleton<IThemeService, ThemeService>();
+
+                        // TaskBar manipulation
+                        services.AddSingleton<ITaskBarService, TaskBarService>();
+
+                        // Service containing navigation, same as INavigationWindow... but without window
+                        services.AddSingleton<INavigationService, NavigationService>();
+
+                        // Main window with navigation
+                        services.AddScoped<INavigationWindow, Views.Windows.MainWindow>();
+                        services.AddScoped<ViewModels.MainWindowViewModel>();
+
+                        // Views and ViewModels
+                        services.AddScoped<Views.Pages.DashboardPage>();
+                        services.AddScoped<ViewModels.DashboardViewModel>();
+                        services.AddScoped<Views.Pages.CustomPresets>();
+                        services.AddScoped<Views.Pages.Premade>();
+                        services.AddScoped<Views.Pages.Adaptive>();
+                        services.AddScoped<Views.Pages.Automations>();
+                        services.AddScoped<Views.Pages.FanControl>();
+                        services.AddScoped<Views.Pages.SystemInfo>();
+                        services.AddScoped<ViewModels.GamesViewModel>();
+                        services.AddScoped<Views.Pages.Games>();
+                        services.AddScoped<ViewModels.CustomPresetsViewModel>();
+                        services.AddScoped<Views.Pages.DataPage>();
+                        services.AddScoped<ViewModels.DataViewModel>();
+                        services.AddScoped<Views.Pages.SettingsPage>();
+                        services.AddScoped<ViewModels.SettingsViewModel>();
+
+                        // Configuration
+                        services.Configure<AppConfig>(context.Configuration.GetSection(nameof(AppConfig)));
+                    }).Build();
+
+                _logger = _host.Services.GetRequiredService<ILogger<App>>();
+
+                _ = Tablet.TabletDevices;
+                bool firstBoot = false;
+                try
+                {
+                    if (Settings.Default.SettingsUpgradeRequired)
+                    {
+                        try
+                        {
+                            Settings.Default.Upgrade();
+                            Settings.Default.SettingsUpgradeRequired = false;
+                            Settings.Default.Save();
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Failed to update settings on startup");
                         }
                     }
 
-                    if (IsInternetAvailable()) if (Settings.Default.UpdateCheck) CheckForUpdate();
+                    firstBoot = Settings.Default.FirstBoot;
+                }
+                catch (ConfigurationErrorsException ex)
+                {
+                    string filename = ((ConfigurationErrorsException)ex.InnerException).Filename;
+                    File.Delete(filename);
+                    Settings.Default.Reload();
+                }
 
-                    await _host.StartAsync();
+                bool createdNew;
+                mutex = new Mutex(true, MutexName, out createdNew);
+
+                if (!createdNew)
+                {
+                    _logger.LogWarning("Failed to start app, as there is already running uxtu instance. Shutting down");
+                    MessageBox.Show("An instance of Universal x86 Tuning Utility is already open!", "Error starting Universal x86 Tuning Utility");
+                    // Close the new instance
+                    Shutdown();
+                    return;
+                }
+
+                if (File.Exists("C:\\Universal.x86.Tuning.Utility.V2.msi")) File.Delete("C:\\Universal.x86.Tuning.Utility.V2.msi");
+
+                Family.setCpuFamily();
+                Family.setCpuFamily();
+                string path = System.Reflection.Assembly.GetEntryAssembly().Location;
+                path = path.Replace("Universal x86 Tuning Utility.dll", null);
+
+                if (firstBoot || Settings.Default.Path != path)
+                {
+                    Settings.Default.Path = path;
+                    Settings.Default.FirstBoot = false;
+                    if (Family.FAM > Family.RyzenFamily.Rembrandt || Family.FAM == Family.RyzenFamily.Mendocino) Settings.Default.polling = 3;
+                    Settings.Default.Save();
+
+                    //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFAUTONOMOUS", 1, true);
+                    //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFAUTONOMOUS", 1, false);
+                    //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFEPP", 50, true);
+                    //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFEPP", 50, false);
+                    //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFEPP1", 50, true);
+                    //PowerPlans.SetPowerValue("scheme_current", "sub_processor", "PERFEPP1", 50, false);
+
+                    try
+                    {
+                        await Task.Run(() => UnblockFilesInDirectory(path));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to unblock files in {dir} directory", path);
+                    }
+                }
+
+                if (IsInternetAvailable()) if (Settings.Default.UpdateCheck) CheckForUpdate();
+
+                await _host.StartAsync();
 
                 await Task.Run(() => Game_Manager.installedGames = Game_Manager.syncGame_Library());
             } 

--- a/Universal x86 Tuning Utility/app.manifest
+++ b/Universal x86 Tuning Utility/app.manifest
@@ -16,7 +16,7 @@
             Remove this element if your application requires this virtualization for backwards
             compatibility.
         -->
-        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
       </requestedPrivileges>
     </security>
   </trustInfo>


### PR DESCRIPTION
Replaces manual user role check with "requireAdministrator" in app.manifest

From user standpoint it makes obvious, that app requires administrator permissions (shield icon) and improves startup time a bit
From developer standpoint it makes a bit easier to debug app: VisualStudio automatically offers to restart IDE with administrator rights if not yet, Rider writes message to console, asking for elevated permissions

Was:
![image](https://github.com/JamesCJ60/Universal-x86-Tuning-Utility/assets/29174280/88ae4564-84ef-4872-890c-cf8619340e9a)

Now:
![image](https://github.com/JamesCJ60/Universal-x86-Tuning-Utility/assets/29174280/d39da5c0-d04e-4a82-bb33-d5ef760b007e)

(have no idea why GitHub fails to detect identation fix properly, so moved it to separate commit)