### PR TITLE
Fix log directory path in Windows service startup

### DIFF
--- a/Universal x86 Tuning Utility/App.xaml.cs
+++ b/Universal x86 Tuning Utility/App.xaml.cs
@@ -72,7 +72,7 @@ namespace Universal_x86_Tuning_Utility
         /// </summary>
         private async void OnStartup(object sender, StartupEventArgs e)
         {
-            Environment.CurrentDirectory = AppDomain.CurrentDomain.BaseDirectory
+            Environment.CurrentDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
             Log.Logger = new LoggerConfiguration()
                 .WriteTo.Console(theme: AnsiConsoleTheme.Code, applyThemeToRedirectedOutput: true)

--- a/Universal x86 Tuning Utility/App.xaml.cs
+++ b/Universal x86 Tuning Utility/App.xaml.cs
@@ -72,6 +72,8 @@ namespace Universal_x86_Tuning_Utility
         /// </summary>
         private async void OnStartup(object sender, StartupEventArgs e)
         {
+            Environment.CurrentDirectory = AppDomain.CurrentDomain.BaseDirectory
+
             Log.Logger = new LoggerConfiguration()
                 .WriteTo.Console(theme: AnsiConsoleTheme.Code, applyThemeToRedirectedOutput: true)
                 .WriteTo.File(LOGS_FOLDER + "uxtu_log.txt", 


### PR DESCRIPTION
When running as a Windows service (the setting in UXTU is `Settings - Start on System Boot`), it will cause the log storage directory to be `C:\Windows\System32\Logs`.