### PR TITLE
Some UX updates. Restore AutoReapplyTime and handle CustomPresets actions

### DIFF
--- a/Universal x86 Tuning Utility/Properties/Settings.Designer.cs
+++ b/Universal x86 Tuning Utility/Properties/Settings.Designer.cs
@@ -45,7 +45,22 @@ namespace Universal_x86_Tuning_Utility.Properties {
                 this["StartMini"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string cstmPreset
+        {
+            get
+            {
+                return ((string)(this["cstmPreset"]));
+            }
+            set
+            {
+                this["cstmPreset"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]

--- a/Universal x86 Tuning Utility/Views/Pages/SettingsPage.xaml
+++ b/Universal x86 Tuning Utility/Views/Pages/SettingsPage.xaml
@@ -45,7 +45,7 @@
         <CheckBox Name="cbApplyStart" Click="cbApplyStart_Click">Reapply On Start</CheckBox>
         <StackPanel Orientation="Horizontal">
             <CheckBox Name="cbAutoReapply" Click="cbAutoReapply_Click">Auto Reapply (s)</CheckBox>
-            <ui:NumberBox Name="nudAutoReapply" Minimum="1" Value="3" Maximum="60" Margin="9,0,0,0" TextChanged="nudAutoReapply_TextChanged" MaxDecimalPlaces="0" ValueChanged="nudAutoReapply_ValueChanged"></ui:NumberBox>
+            <ui:NumberBox Name="nudAutoReapply" Minimum="1" Maximum="90" Margin="9,0,0,0" TextChanged="nudAutoReapply_TextChanged" MaxDecimalPlaces="0" ValueChanged="nudAutoReapply_ValueChanged"></ui:NumberBox>
         </StackPanel>
         <CheckBox Name="cbAutoCheck" Click="cbAutoCheck_Click">Auto Update Check</CheckBox>
         <CheckBox Name="cbAdaptive" Click="cbAdaptive_Click">Auto Start Adaptive Mode</CheckBox>

--- a/Universal x86 Tuning Utility/Views/Pages/SettingsPage.xaml.cs
+++ b/Universal x86 Tuning Utility/Views/Pages/SettingsPage.xaml.cs
@@ -239,7 +239,11 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
 
         private void nudAutoReapply_ValueChanged(object sender, RoutedEventArgs e)
         {
-
+            if (nudAutoReapply != null && nudAutoReapply.Value != null)
+            {
+                Settings.Default.AutoReapplyTime = (int)nudAutoReapply.Value;
+                Settings.Default.Save();
+            }
         }
     }
 }


### PR DESCRIPTION
Hello! Here some updates that I found useful from UI/UX perspective:

1. Remove default value "3" for `nudAutoReapply`, so it loads from settings
2. Added current preset field to keep active preset in settings and restore it on launch
3. Added default presets and updated save and delete button actions to perform more complete tasks:
* Save button changes current preset, so it is considered as selected.
* Delete button removes active preset and restores default preset.