### PR TITLE
Add configurable diagnostic logging for silenced exceptions

### DIFF
--- a/Universal x86 Tuning Utility/App.config
+++ b/Universal x86 Tuning Utility/App.config
@@ -196,6 +196,9 @@
             <setting name="cstmPreset" serializeAs="String">
                 <value />
             </setting>
+            <setting name="DiagnosticLogLevel" serializeAs="String">
+                <value>1</value>
+            </setting>
         </Universal_x86_Tuning_Utility.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Universal x86 Tuning Utility/App.xaml.cs
+++ b/Universal x86 Tuning Utility/App.xaml.cs
@@ -79,12 +79,15 @@ namespace Universal_x86_Tuning_Utility
             Environment.CurrentDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
             Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.ControlledBy(Scripts.Misc.DiagnosticLogger.LevelSwitch)
                 .WriteTo.Console(theme: AnsiConsoleTheme.Code, applyThemeToRedirectedOutput: true)
                 .WriteTo.File(LOGS_FOLDER + "uxtu_log.txt",
                     fileSizeLimitBytes: 8 * 1024 * 1024, // 8MB
                     rollingInterval: RollingInterval.Day
                 )
                 .CreateLogger();
+
+            Scripts.Misc.DiagnosticLogger.ApplySettingsLevel();
 
             if (!IsVcRedistInstalled("x64") && !IsVcRedistInstalled("x86"))
             {

--- a/Universal x86 Tuning Utility/Properties/Settings.Designer.cs
+++ b/Universal x86 Tuning Utility/Properties/Settings.Designer.cs
@@ -778,5 +778,17 @@ namespace Universal_x86_Tuning_Utility.Properties {
                 this["cstmPreset"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        public int DiagnosticLogLevel {
+            get {
+                return ((int)(this["DiagnosticLogLevel"]));
+            }
+            set {
+                this["DiagnosticLogLevel"] = value;
+            }
+        }
     }
 }

--- a/Universal x86 Tuning Utility/Properties/Settings.settings
+++ b/Universal x86 Tuning Utility/Properties/Settings.settings
@@ -191,5 +191,8 @@
     <Setting Name="cstmPreset" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="DiagnosticLogLevel" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Universal x86 Tuning Utility/Scripts/Adaptive/CPUControl.cs
+++ b/Universal x86 Tuning Utility/Scripts/Adaptive/CPUControl.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Universal_x86_Tuning_Utility.Scripts.Misc;
 
 namespace Universal_x86_Tuning_Utility.Scripts.Adaptive
 {
@@ -81,7 +82,11 @@ namespace Universal_x86_Tuning_Utility.Scripts.Adaptive
                         _lastPowerLimit = _newPowerLimit;
                     }
                 } 
-            } catch { }
+            }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to update power limit");
+            }
 
 
             _lastUsage = cpuLoad;
@@ -132,7 +137,11 @@ namespace Universal_x86_Tuning_Utility.Scripts.Adaptive
 
                 // Apply new CO
                 if (_newCO != _lastCO) UpdateCO(_newCO);
-            } catch { }
+            }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to update curve optimiser");
+            }
         }
 
         private static async void UpdateCO(int _newCO)

--- a/Universal x86 Tuning Utility/Scripts/Family.cs
+++ b/Universal x86 Tuning Utility/Scripts/Family.cs
@@ -104,7 +104,11 @@ namespace Universal_x86_Tuning_Utility.Scripts
                 try
                 {
                     //App.memTimings = Mem_Timings.RetrieveTimings();
-                } catch { }
+                }
+                catch (Exception ex)
+                {
+                    Misc.DiagnosticLogger.LogError(ex, "Failed to retrieve memory timings");
+                }
 
                 //Zen1 - Zen2
                 if (CPUFamily == 23)

--- a/Universal x86 Tuning Utility/Scripts/Game_Manager.cs
+++ b/Universal x86 Tuning Utility/Scripts/Game_Manager.cs
@@ -238,7 +238,10 @@ namespace Universal_x86_Tuning_Utility.Scripts
                             }
                         }
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        Misc.DiagnosticLogger.LogError(ex, "Failed to process game library entry");
+                    }
                 }
 
                 list = list.OrderBy(item => item.gameName).ToList();
@@ -351,7 +354,10 @@ namespace Universal_x86_Tuning_Utility.Scripts
                     });
                 }
             }
-            catch { /* ignore */ }
+            catch (Exception ex)
+            {
+                Misc.DiagnosticLogger.LogError(ex, "Failed to launch game process");
+            }
         }
 
 
@@ -368,7 +374,10 @@ namespace Universal_x86_Tuning_Utility.Scripts
                 System.Diagnostics.Process.Start(psi);
 
             }
-            catch { /* ignore */ }
+            catch (Exception ex)
+            {
+                Misc.DiagnosticLogger.LogError(ex, "Failed to run launch string");
+            }
         }
 
         public static bool BattleNetRunning()

--- a/Universal x86 Tuning Utility/Scripts/Intel Backend/Intel_Management.cs
+++ b/Universal x86 Tuning Utility/Scripts/Intel Backend/Intel_Management.cs
@@ -25,12 +25,18 @@ namespace Universal_x86_Tuning_Utility.Scripts.Intel_Backend
             {
                 runIntelTDPChangeMSR(pl, pl);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Misc.DiagnosticLogger.LogError(ex, "Failed to change Intel TDP MSR");
+            }
 
             //try { 
             //    runIntelTDPChangeMMIOKX(pl, pl); 
             //}
-            //catch { }
+            //catch (Exception ex)
+            //{
+            //    Misc.DiagnosticLogger.LogError(ex, "Failed to change Intel TDP MMIOKX");
+            //}
         }
 
         public static void changePowerBalance(int value, int cpuOrGpu)
@@ -228,7 +234,10 @@ namespace Universal_x86_Tuning_Utility.Scripts.Intel_Backend
                 Run_CLI.RunCommand(commandArguments, false, processMSR);
                 Task.Delay(100);
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                Misc.DiagnosticLogger.LogError(ex, "Failed to change Intel power balance via MSR");
+            }
         }
 
         public static void checkDriverBlockRegistry()

--- a/Universal x86 Tuning Utility/Scripts/Misc/DiagnosticLogger.cs
+++ b/Universal x86 Tuning Utility/Scripts/Misc/DiagnosticLogger.cs
@@ -1,0 +1,53 @@
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Universal_x86_Tuning_Utility.Scripts.Misc
+{
+    internal static class DiagnosticLogger
+    {
+        public static readonly LoggingLevelSwitch LevelSwitch = new(LogEventLevel.Warning);
+
+        public static void ApplySettingsLevel()
+        {
+            LevelSwitch.MinimumLevel = Properties.Settings.Default.DiagnosticLogLevel switch
+            {
+                0 => LogEventLevel.Fatal + 1,
+                1 => LogEventLevel.Warning,
+                2 => LogEventLevel.Information,
+                3 => LogEventLevel.Debug,
+                _ => LogEventLevel.Warning
+            };
+        }
+
+        public static void LogError(
+            Exception ex,
+            string context,
+            [CallerMemberName] string caller = "",
+            [CallerFilePath] string file = "")
+        {
+            Log.Warning(ex, "[{Source}.{Caller}] {Context}",
+                System.IO.Path.GetFileNameWithoutExtension(file), caller, context);
+        }
+
+        public static void LogInfo(
+            string message,
+            [CallerMemberName] string caller = "",
+            [CallerFilePath] string file = "")
+        {
+            Log.Information("[{Source}.{Caller}] {Message}",
+                System.IO.Path.GetFileNameWithoutExtension(file), caller, message);
+        }
+
+        public static void LogDebug(
+            string message,
+            [CallerMemberName] string caller = "",
+            [CallerFilePath] string file = "")
+        {
+            Log.Debug("[{Source}.{Caller}] {Message}",
+                System.IO.Path.GetFileNameWithoutExtension(file), caller, message);
+        }
+    }
+}

--- a/Universal x86 Tuning Utility/Scripts/Misc/Garbage.cs
+++ b/Universal x86 Tuning Utility/Scripts/Misc/Garbage.cs
@@ -23,9 +23,9 @@ namespace Universal_x86_Tuning_Utility.Scripts.Misc
                     long usedMemory = GC.GetTotalMemory(true);
                 });
             }
-            catch
+            catch (Exception ex)
             {
-
+                DiagnosticLogger.LogError(ex, "Failed to collect garbage");
             }
         }
     }

--- a/Universal x86 Tuning Utility/Scripts/Misc/GetImages.cs
+++ b/Universal x86 Tuning Utility/Scripts/Misc/GetImages.cs
@@ -134,7 +134,10 @@ namespace Universal_x86_Tuning_Utility.Scripts.Misc
                 else return path + $"\\Assets\\GameImages\\{CleanFileName(gameName)}.jpeg";
 
             }
-            catch { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to get game image");
+            }
             return path + "\\Assets\\GameImages\\default.png";
         }
 

--- a/Universal x86 Tuning Utility/Scripts/Misc/GetSystemInfo.cs
+++ b/Universal x86 Tuning Utility/Scripts/Misc/GetSystemInfo.cs
@@ -60,7 +60,10 @@ namespace Universal_x86_Tuning_Utility.Scripts.Misc
                     return obj["Name"].ToString();
                 }
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to get CPU name");
+            }
             return "";
         }
         public static string GetGPUName(int i)
@@ -802,7 +805,7 @@ namespace Universal_x86_Tuning_Utility.Scripts.Misc
             }
             catch (ManagementException ex)
             {
-
+                DiagnosticLogger.LogError(ex, "Failed to check virtualization status");
             }
 
             return false;

--- a/Universal x86 Tuning Utility/Scripts/Misc/ToastNotification.cs
+++ b/Universal x86 Tuning Utility/Scripts/Misc/ToastNotification.cs
@@ -25,7 +25,11 @@ namespace Universal_x86_Tuning_Utility.Scripts.Misc
                    .AddText(body)
                    .AddAppLogoOverride(new Uri(iconUri))
                    .Show();
-            } catch (Exception ex) { }
+            }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to show toast notification");
+            }
         }
     }
 }

--- a/Universal x86 Tuning Utility/Scripts/PremadePresets.cs
+++ b/Universal x86 Tuning Utility/Scripts/PremadePresets.cs
@@ -260,7 +260,10 @@ namespace Universal_x86_Tuning_Utility.Scripts
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Misc.DiagnosticLogger.LogError(ex, "Failed to set premade presets");
+            }
         }
     }
 }

--- a/Universal x86 Tuning Utility/Scripts/RyzenAdj_To_UXTU.cs
+++ b/Universal x86 Tuning Utility/Scripts/RyzenAdj_To_UXTU.cs
@@ -15,6 +15,7 @@ using Universal_x86_Tuning_Utility.Scripts.ASUS;
 using Universal_x86_Tuning_Utility.Scripts.GPUs.AMD;
 using Universal_x86_Tuning_Utility.Scripts.GPUs.NVIDIA;
 using Universal_x86_Tuning_Utility.Scripts.Intel_Backend;
+using Universal_x86_Tuning_Utility.Scripts.Misc;
 using Universal_x86_Tuning_Utility.Services;
 using Settings = Universal_x86_Tuning_Utility.Properties.Settings;
 
@@ -42,6 +43,7 @@ namespace Universal_x86_Tuning_Utility.Scripts
                 string[] ryzenAdjCommands = _ryzenAdjString.Split(' ');
                 ryzenAdjCommands = ryzenAdjCommands.Distinct().ToArray();
 
+                DiagnosticLogger.LogDebug($"Translate string: {_ryzenAdjString}");
                 //MessageBox.Show(_ryzenAdjString);
                 //Run through array
                 foreach (string ryzenAdjCommand in ryzenAdjCommands)
@@ -57,6 +59,7 @@ namespace Universal_x86_Tuning_Utility.Scripts
                             // Extract the command string after the "=" sign
                             string ryzenAdjCommandValueString = command.Substring(ryzenAdjCommand.IndexOf('=') + 1);
 
+                            DiagnosticLogger.LogDebug($"Processing: {ryzenAdjCommandString}={ryzenAdjCommandValueString}");
 
                             if (ryzenAdjCommandString.Contains("UXTUSR"))
                             {
@@ -136,19 +139,29 @@ namespace Universal_x86_Tuning_Utility.Scripts
 
                                 if (ryzenAdjCommandValue <= 0 && !ryzenAdjCommandString.Contains("co")) SMUCommands.applySettings(ryzenAdjCommandString, 0x0);
                                 else SMUCommands.applySettings(ryzenAdjCommandString, ryzenAdjCommandValue);
+
+                                DiagnosticLogger.LogDebug($"SMU applied: {ryzenAdjCommandString}=0x{ryzenAdjCommandValue:X}");
                                 Task.Delay(50);
                             }
                         }
-                        catch (Exception ex) { }
+                        catch (Exception ex)
+                        {
+                            DiagnosticLogger.LogError(ex, $"Failed to process command: {ryzenAdjCommand}");
+                        }
                     });
                 }
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to translate RyzenAdj command string");
+            }
         }
+
         private static void ADLX(string command, string value)
         {
             try
             {
+                DiagnosticLogger.LogDebug($"ADLX: {command}={value}");
                 string[] variables = value.Split('-');
 
                 if (command == "ADLX-Lag") ADLXBackend.SetAntiLag(int.Parse(variables[0]), bool.Parse(variables[1]));
@@ -162,13 +175,17 @@ namespace Universal_x86_Tuning_Utility.Scripts
                 if (command == "ADLX-Sync") ADLXBackend.SetEnhancedSync(int.Parse(variables[0]), bool.Parse(variables[1]));
                 if (command == "ADLX-ImageSharp") ADLXBackend.SetImageSharpning(int.Parse(variables[0]), bool.Parse(variables[1]), int.Parse(variables[2]));
             }
-            catch { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to apply ADLX settings");
+            }
         }
 
         private static void UXTUSR(string command, string value)
         {
             try
             {
+                DiagnosticLogger.LogDebug($"UXTUSR: {command}={value}");
                 string[] variables = value.Split('-');
 
                 if (command == "UXTUSR")
@@ -182,13 +199,17 @@ namespace Universal_x86_Tuning_Utility.Scripts
                     Universal_x86_Tuning_Utility.Properties.Settings.Default.Save();
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to apply UXTUSR settings");
+            }
         }
 
         private static void NVIDIA(string command, string value)
         {
             try
             {
+                DiagnosticLogger.LogDebug($"NVIDIA: {command}={value}");
                 string[] variables = value.Split('-');
 
                 if (command == "NVIDIA-Clocks" && variables.Length == 2) NvTuning.SetClocks(int.Parse(variables[0]), int.Parse(variables[1]));
@@ -198,7 +219,10 @@ namespace Universal_x86_Tuning_Utility.Scripts
                     NvTuning.SetClocks(int.Parse(variables[1]), int.Parse(variables[2]));
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to apply NVIDIA clocks");
+            }
         }
 
         static bool isMessageBoxOpen = false, isUpdatingUltiMode = false;
@@ -206,6 +230,7 @@ namespace Universal_x86_Tuning_Utility.Scripts
         {
             try
             {
+                DiagnosticLogger.LogDebug($"AsusWmi: {command}={value}");
                 uint id = 0;
                 int mode = 0;
                 if (command == "ASUS-Power")
@@ -265,7 +290,10 @@ namespace Universal_x86_Tuning_Utility.Scripts
                     }
                 }
             } 
-            catch { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to apply ASUS WMI settings");
+            }
         }
 
         private static void MessageBox_Enable(object sender, System.Windows.RoutedEventArgs e)

--- a/Universal x86 Tuning Utility/Views/Pages/Adaptive.xaml.cs
+++ b/Universal x86 Tuning Utility/Views/Pages/Adaptive.xaml.cs
@@ -161,7 +161,10 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
 
                 if (Settings.Default.isStartAdpative) ToggleAdaptiveMode();
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed during adaptive mode setup");
+            }
         }
 
         [DllImport("user32.dll")]
@@ -209,7 +212,10 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                     Settings.Default.Save();
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to toggle adaptive mode");
+            }
         }
 
         public static int CPUTemp, CPULoad, CPUClock, CPUPower, GPULoad, GPUClock, GPUMemClock;
@@ -298,7 +304,10 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                     cbxResScale.SelectedIndex = myPreset.ResScaleIndex;
                 }
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to load adaptive preset");
+            }
         }
 
         private void savePreset(string presetName)
@@ -338,7 +347,10 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                 };
                 adaptivePresetManager.SavePreset(presetName, preset);
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to save adaptive preset");
+            }
         }
 
         private static LASTINPUTINFO lastInput = new LASTINPUTINFO();
@@ -356,7 +368,10 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                 foreach (GameLauncherItem item in Game_Manager.installedGames) cbxPowerPreset.Items.Add(item.gameName);
                 cbxPowerPreset.SelectedIndex = 0;
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to reload game apps");
+            }
         }
 
         private void btnSave_Click(object sender, RoutedEventArgs e)
@@ -426,7 +441,10 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
 
                 }
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed during sensor tick");
+            }
         }
 
         public static int GetRadeonGPUCount()
@@ -560,7 +578,10 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                     //}
                 }
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed during adaptive mode update");
+            }
         }
 
         public bool IsScrollBarVisible(ScrollViewer scrollViewer)
@@ -623,7 +644,7 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                         }
                         catch (Exception ex)
                         {
-
+                            DiagnosticLogger.LogError(ex, "Failed to check running game process");
                         }
                     }
                     i++;

--- a/Universal x86 Tuning Utility/Views/Pages/CustomPresets.xaml.cs
+++ b/Universal x86 Tuning Utility/Views/Pages/CustomPresets.xaml.cs
@@ -724,7 +724,10 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                     }
                 }
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to delete preset");
+            }
         }
 
 
@@ -1052,7 +1055,10 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
                 }
                 Garbage.Garbage_Collect();
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed to update preset values");
+            }
         }
 
         public string getCommandValues()

--- a/Universal x86 Tuning Utility/Views/Pages/SettingsPage.xaml
+++ b/Universal x86 Tuning Utility/Views/Pages/SettingsPage.xaml
@@ -50,6 +50,15 @@
         <CheckBox Name="cbAutoCheck" Click="cbAutoCheck_Click">Auto Update Check</CheckBox>
         <CheckBox Name="cbAdaptive" Click="cbAdaptive_Click">Auto Start Adaptive Mode</CheckBox>
         <CheckBox Name="cbTrack" Click="cbTrack_Click">Track Games</CheckBox>
+
+        <TextBlock Margin="0,12,0,4" Text="Diagnostic Logging" />
+        <ComboBox Name="cbxLogLevel" Width="200" HorizontalAlignment="Left" SelectionChanged="cbxLogLevel_SelectionChanged">
+            <ComboBoxItem>Off</ComboBoxItem>
+            <ComboBoxItem>Error only</ComboBoxItem>
+            <ComboBoxItem>Info</ComboBoxItem>
+            <ComboBoxItem>Debug</ComboBoxItem>
+        </ComboBox>
+
         <ui:Button Name="btnStressTest" Width="178" Click="btnStressTest_Click" Margin="0,9,0,0">
             <StackPanel Orientation="Horizontal">
                 <ui:SymbolIcon Symbol="Fire20" FontSize="24" Margin="0,0,9,0"/>

--- a/Universal x86 Tuning Utility/Views/Pages/SettingsPage.xaml.cs
+++ b/Universal x86 Tuning Utility/Views/Pages/SettingsPage.xaml.cs
@@ -43,6 +43,8 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
             cbAdaptive.IsChecked = Settings.Default.isStartAdpative;
             cbTrack.IsChecked = Settings.Default.isTrack;
 
+            cbxLogLevel.SelectedIndex = Settings.Default.DiagnosticLogLevel;
+
             checkUpdate();
         }
 
@@ -235,6 +237,18 @@ namespace Universal_x86_Tuning_Utility.Views.Pages
         {
             Settings.Default.isTrack = (bool)cbTrack.IsChecked;
             Settings.Default.Save();
+        }
+
+        private void cbxLogLevel_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (cbxLogLevel == null)
+            {
+                return;
+            }
+
+            Settings.Default.DiagnosticLogLevel = cbxLogLevel.SelectedIndex;
+            Settings.Default.Save();
+            DiagnosticLogger.ApplySettingsLevel();
         }
 
         private void nudAutoReapply_ValueChanged(object sender, RoutedEventArgs e)

--- a/Universal x86 Tuning Utility/Views/Windows/MainWindow.xaml.cs
+++ b/Universal x86 Tuning Utility/Views/Windows/MainWindow.xaml.cs
@@ -341,7 +341,10 @@ namespace Universal_x86_Tuning_Utility.Views.Windows
                     monitor = null;
                 }
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed during RTSS performance tracking tick");
+            }
         }
 
         private async Task ProcessGamePerformanceData(GameLauncherItem game)
@@ -403,9 +406,10 @@ namespace Universal_x86_Tuning_Utility.Views.Windows
                     statuscode = (ushort)battery["BatteryStatus"];
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 // Handle exceptions if necessary
+                DiagnosticLogger.LogError(ex, "Failed to get battery status");
             }
         }
 
@@ -437,7 +441,10 @@ namespace Universal_x86_Tuning_Utility.Views.Windows
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed during auto-reapply tick");
+            }
         }
         int i = 0;
         async void GC_Tick(object sender, EventArgs e)
@@ -570,7 +577,10 @@ namespace Universal_x86_Tuning_Utility.Views.Windows
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                DiagnosticLogger.LogError(ex, "Failed during power mode change handling");
+            }
         }
 
         #region INavigationWindow Methods


### PR DESCRIPTION
## Problem

30+ catch blocks across the project silently swallow exceptions (`catch { }` / `catch (Exception ex) { }`), making it impossible to diagnose issues in the field.

## Solution

Added a lightweight `DiagnosticLogger` wrapper over the existing Serilog pipeline with a user-facing level switch on the Settings page.

### How it works

- `DiagnosticLogger.LevelSwitch` controls Serilog's `MinimumLevel` at runtime
- Setting `DiagnosticLogLevel` in user settings: **0**=Off, **1**=Error only (default), **2**=Info, **3**=Debug
- Logs go to the same `./logs/uxtu_log.txt` (daily rolling, 8MB cap)
- When Off — Serilog drops events before formatting, zero overhead

### What changed

- **New:** `Scripts/Misc/DiagnosticLogger.cs` — static wrapper with `LogError`, `LogInfo`, `LogDebug`
- **Settings:** Added `DiagnosticLogLevel` to `App.config`, `Settings.settings`, `Settings.Designer.cs`
- **UI:** ComboBox on Settings page (Off / Error only / Info / Debug), applies immediately
- **Serilog:** Connected `LoggingLevelSwitch` via `MinimumLevel.ControlledBy()` in `App.xaml.cs`
- **30+ catch blocks** replaced with `DiagnosticLogger.LogError(ex, "context")` across 15 files
- **Debug tracing** in `RyzenAdj_To_UXTU`: logs every command, SMU writes (hex values), ADLX/NVIDIA/ASUS operations
